### PR TITLE
Change bodyFormat through config

### DIFF
--- a/config/magento.php
+++ b/config/magento.php
@@ -32,6 +32,8 @@ return [
 
             /* Authentication method, choose either "oauth" or "token". */
             'authentication_method' => env('MAGENTO_AUTH_METHOD', 'token'),
+
+            'body_format' => env('MAGENTO_BODY_FORMAT', 'json'),
         ],
     ],
 

--- a/src/Actions/BuildRequest.php
+++ b/src/Actions/BuildRequest.php
@@ -22,8 +22,19 @@ class BuildRequest implements BuildsRequest
         $pendingRequest = Http::baseUrl($options['base_url'])
             ->timeout($options['timeout'])
             ->connectTimeout($options['connect_timeout'])
-            ->acceptJson()
-            ->asJson();
+            ->acceptJson();
+
+        switch ($options['body_format']) {
+            case 'multipart':
+                $pendingRequest->asMultipart();
+                break;
+            case 'form':
+                $pendingRequest->asForm();
+                break;
+            default:
+                $pendingRequest->asJson();
+                break;
+        }
 
         return $this->request->authenticate($pendingRequest, $connection);
     }


### PR DESCRIPTION
## Hey

I need to change the bodyFormat of the requests which will be sent through the client. I could not find any configuration to do this, so I've added one.

- New config `body_format` per connection which defaults to json.
- New environment variable `MAGENTO_BODY_FORMAT`.
- Install the value into the PendingRequest object.